### PR TITLE
added missing overload to task function

### DIFF
--- a/4.0.0-alpha.2/index.d.ts
+++ b/4.0.0-alpha.2/index.d.ts
@@ -105,6 +105,7 @@ declare namespace GulpClient {
          */
         task(fn: TaskFunction): TaskFunction;
         task(name: string): TaskFunction;
+        task(name: string, tasks: string[]): TaskFunction;
         task(name: string, fn: TaskFunction): TaskFunction;
         task(name: string, dependencies: string[], fn: TaskFunction): TaskFunction;
 


### PR DESCRIPTION
gulp is able to receive also a name as the first parameter and an array of tasks names to execute as the second parameter
