### PR TITLE
rewrote 3.9.1 type definitions

### DIFF
--- a/3.9.1/index.d.ts
+++ b/3.9.1/index.d.ts
@@ -19,7 +19,7 @@ declare interface RunMethod {
   (taskName: string): void;
 }
 
-declare interface GulpPrototype {
+declare interface Gulp {
   dest: typeof dest;
   src: typeof src;
   /**
@@ -41,12 +41,10 @@ declare interface GulpPrototype {
   Gulp: GulpStatic;
 }
 
-declare type Gulp = GulpPrototype;
-
 declare interface GulpStatic {
   new (): Gulp;
-  prototype: GulpPrototype;
+  prototype: Gulp;
 }
 
-declare let inst: GulpPrototype;
+declare let inst: Gulp;
 export = inst;

--- a/3.9.1/index.d.ts
+++ b/3.9.1/index.d.ts
@@ -3,7 +3,8 @@
 // Definitions by: Marcel Mundl <Marcel@Mundlhome.de>
 
 import * as Orchestrator from "orchestrator";
-import {dest, src} from "vinyl-fs";
+// TODO: uncomment watch once typings is ok again
+import {dest, src, /* watch */} from "vinyl-fs";
 import {EventEmitter} from "events";
 
 // ** hotfix for watch() not being in typings (copied over from @types/vinyl-fs) **

--- a/3.9.1/index.d.ts
+++ b/3.9.1/index.d.ts
@@ -1,286 +1,45 @@
-// Type definitions for Gulp v3.8.x
+// Type definitions for Gulp v3.9.1
 // Project: http://gulpjs.com
-// Original Definitions by: Drew Noakes <https://drewnoakes.com>
+// Definitions by: Marcel Mundl <Marcel@Mundlhome.de>
 
-import Orchestrator = require('orchestrator');
-import { EventEmitter } from 'events';
-import { Duplex } from 'stream';
+import Orchestrator = require("orchestrator");
+import {dest, src, watch} from "vinyl-fs";
 
-declare module gulp {
-  interface Gulp extends Orchestrator {
-    /**
-     * Define a task
-     * @param name The name of the task.
-     * @param deps An array of task names to be executed and completed before your task will run.
-     * @param fn The function that performs the task's operations. For asynchronous tasks, you need to provide a hint when the task is complete:
-     * <ul>
-     *     <li>Take in a callback</li>
-     *     <li>Return a stream or a promise</li>
-     * </ul>
-     */
-    task: Orchestrator.AddMethod;
-    /**
-     * Emits files matching provided glob or an array of globs. Returns a stream of Vinyl files that can be piped to plugins.
-     * @param glob Glob or array of globs to read.
-     * @param opt Options to pass to node-glob through glob-stream.
-     */
-    src: SrcMethod;
-    /**
-     * Can be piped to and it will write files. Re-emits all data passed to it so you can pipe to multiple folders.
-     * Folders that don't exist will be created.
-     *
-     * @param outFolder The path (output folder) to write files to. Or a function that returns it, the function will be provided a vinyl File instance.
-     * @param opt
-     */
-    dest: DestMethod;
-    /**
-     * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
-     *
-     * @param glob a single glob or array of globs that indicate which files to watch for changes.
-     * @param opt options, that are passed to the gaze library.
-     * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
-     */
-    watch: WatchMethod;
-  }
-
-  interface GulpPlugin {
-    (...args: any[]): Duplex;
-  }
-
-  interface WatchMethod {
-    /**
-     * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
-     *
-     * @param glob a single glob or array of globs that indicate which files to watch for changes.
-     * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
-     */
-    (glob: string | string[], fn: (WatchCallback | string)): EventEmitter;
-    /**
-     * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
-     *
-     * @param glob a single glob or array of globs that indicate which files to watch for changes.
-     * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
-     */
-    (glob: string | string[], fn: (WatchCallback | string)[]): EventEmitter;
-    /**
-     * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
-     *
-     * @param glob a single glob or array of globs that indicate which files to watch for changes.
-     * @param opt options, that are passed to the gaze library.
-     * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
-     */
-    (glob: string | string[], opt: WatchOptions, fn: (WatchCallback | string)): EventEmitter;
-    /**
-     * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
-     *
-     * @param glob a single glob or array of globs that indicate which files to watch for changes.
-     * @param opt options, that are passed to the gaze library.
-     * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
-     */
-    (glob: string | string[], opt: WatchOptions, fn: (WatchCallback | string)[]): EventEmitter;
-
-  }
-
-  interface DestMethod {
-    /**
-     * Can be piped to and it will write files. Re-emits all data passed to it so you can pipe to multiple folders.
-     * Folders that don't exist will be created.
-     *
-     * @param outFolder The path (output folder) to write files to. Or a function that returns it, the function will be provided a vinyl File instance.
-     * @param opt
-     */
-    (outFolder: string | ((file: string) => string), opt?: DestOptions): Duplex;
-  }
-
-  interface SrcMethod {
-    /**
-     * Emits files matching provided glob or an array of globs. Returns a stream of Vinyl files that can be piped to plugins.
-     * @param glob Glob or array of globs to read.
-     * @param opt Options to pass to node-glob through glob-stream.
-     */
-    (glob: string | string[], opt?: SrcOptions): Duplex;
-  }
-
+declare class Gulp extends Orchestrator {
+  dest: typeof dest;
+  src: typeof src;
   /**
-   * Options to pass to node-glob through glob-stream.
-   * Specifies two options in addition to those used by node-glob:
-   * https://github.com/isaacs/node-glob#options
+   * Define a task
+   * @param name The name of the task.
+   * @param deps An array of task names to be executed and completed before your task will run.
+   * @param fn The function that performs the task's operations. For asynchronous tasks, you need to provide a hint when the task is complete:
+   * <ul>
+   *     <li>Take in a callback</li>
+   *     <li>Return a stream or a promise</li>
+   * </ul>
    */
-  interface SrcOptions {
-    /**
-     * Setting this to <code>false</code> will return <code>file.contents</code> as <code>null</code>
-     * and not read the file at all.
-     * Default: <code>true</code>.
-     */
-    read?: boolean;
-
-    /**
-     * Setting this to false will return <code>file.contents</code> as a stream and not buffer files.
-     * This is useful when working with large files.
-     * Note: Plugins might not implement support for streams.
-     * Default: <code>true</code>.
-     */
-    buffer?: boolean;
-
-    /**
-     * The base path of a glob.
-     *
-     * Default is everything before a glob starts.
-     */
-    base?: string;
-
-    /**
-     * The current working directory in which to search.
-     * Defaults to process.cwd().
-     */
-    cwd?: string;
-
-    /**
-     * The place where patterns starting with / will be mounted onto.
-     * Defaults to path.resolve(options.cwd, "/") (/ on Unix systems, and C:\ or some such on Windows.)
-     */
-    root?: string;
-
-    /**
-     * Include .dot files in normal matches and globstar matches.
-     * Note that an explicit dot in a portion of the pattern will always match dot files.
-     */
-    dot?: boolean;
-
-    /**
-     * By default, a pattern starting with a forward-slash will be "mounted" onto the root setting, so that a valid
-     * filesystem path is returned. Set this flag to disable that behavior.
-     */
-    nomount?: boolean;
-
-    /**
-     * Add a / character to directory matches. Note that this requires additional stat calls.
-     */
-    mark?: boolean;
-
-    /**
-     * Don't sort the results.
-     */
-    nosort?: boolean;
-
-    /**
-     * Set to true to stat all results. This reduces performance somewhat, and is completely unnecessary, unless
-     * readdir is presumed to be an untrustworthy indicator of file existence. It will cause ELOOP to be triggered one
-     * level sooner in the case of cyclical symbolic links.
-     */
-    stat?: boolean;
-
-    /**
-     * When an unusual error is encountered when attempting to read a directory, a warning will be printed to stderr.
-     * Set the silent option to true to suppress these warnings.
-     */
-    silent?: boolean;
-
-    /**
-     * When an unusual error is encountered when attempting to read a directory, the process will just continue on in
-     * search of other matches. Set the strict option to raise an error in these cases.
-     */
-    strict?: boolean;
-
-    /**
-     * See cache property above. Pass in a previously generated cache object to save some fs calls.
-     */
-    cache?: boolean;
-
-    /**
-     * A cache of results of filesystem information, to prevent unnecessary stat calls.
-     * While it should not normally be necessary to set this, you may pass the statCache from one glob() call to the
-     * options object of another, if you know that the filesystem will not change between calls.
-     */
-    statCache?: boolean;
-
-    /**
-     * Perform a synchronous glob search.
-     */
-    sync?: boolean;
-
-    /**
-     * In some cases, brace-expanded patterns can result in the same file showing up multiple times in the result set.
-     * By default, this implementation prevents duplicates in the result set. Set this flag to disable that behavior.
-     */
-    nounique?: boolean;
-
-    /**
-     * Set to never return an empty set, instead returning a set containing the pattern itself.
-     * This is the default in glob(3).
-     */
-    nonull?: boolean;
-
-    /**
-     * Perform a case-insensitive match. Note that case-insensitive filesystems will sometimes result in glob returning
-     * results that are case-insensitively matched anyway, since readdir and stat will not raise an error.
-     */
-    nocase?: boolean;
-
-    /**
-     * Set to enable debug logging in minimatch and glob.
-     */
-    debug?: boolean;
-
-    /**
-     * Set to enable debug logging in glob, but not minimatch.
-     */
-    globDebug?: boolean;
-  }
-
-  interface DestOptions {
-    /**
-     * The output folder. Only has an effect if provided output folder is relative.
-     * Default: process.cwd()
-     */
-    cwd?: string;
-
-    /**
-     * Octal permission string specifying mode for any folders that need to be created for output folder.
-     * Default: 0777.
-     */
-    mode?: string;
-  }
-
+  task: typeof Orchestrator.prototype.add;
+  run: RunMethod;
+  watch: typeof watch;
   /**
-   * Options that are passed to <code>gaze</code>.
-   * https://github.com/shama/gaze
+   * The class is a member of itself so that packages can create seperate instances of gulp
    */
-  interface WatchOptions {
-    /** Interval to pass to fs.watchFile. */
-    interval?: number;
-    /** Delay for events called in succession for the same file/event. */
-    debounceDelay?: number;
-    /** Force the watch mode. Either 'auto' (default), 'watch' (force native events), or 'poll' (force stat polling). */
-    mode?: string;
-    /** The current working directory to base file patterns from. Default is process.cwd().. */
-    cwd?: string;
-  }
-
-  interface WatchEvent {
-    /** The type of change that occurred, either added, changed or deleted. */
-    type: string;
-    /** The path to the file that triggered the event. */
-    path: string;
-  }
-
-  /**
-   * Callback to be called on each watched file change.
-   */
-  interface WatchCallback {
-    (event: WatchEvent): void;
-  }
-
-  interface TaskCallback {
-    /**
-     * Defines a task.
-     * Tasks may be made asynchronous if they are passing a callback or return a promise or a stream.
-     * @param cb callback used to signal asynchronous completion. Caller includes <code>err</code> in case of error.
-     */
-    (cb?: (err?: any) => void): any;
-  }
+  Gulp: typeof Gulp;
 }
 
-declare var gulp: gulp.Gulp;
+declare interface RunMethod {
+  /**
+   * Run the "default" task
+   * @deprecated will be removed in gulp 4.0. Use task dependencies instead.
+   */
+  (): void;
+  /**
+   * Run a previously defined task
+   * @param taskName The name of the task to run (optional)
+   * @deprecated will be removed in gulp 4.0. Use task dependencies instead.
+   */
+  (taskName: string): void;
+}
 
-export = gulp;
+declare let inst: Gulp;
+export = inst;

--- a/3.9.1/index.d.ts
+++ b/3.9.1/index.d.ts
@@ -2,8 +2,31 @@
 // Project: http://gulpjs.com
 // Definitions by: Marcel Mundl <Marcel@Mundlhome.de>
 
-import Orchestrator = require("orchestrator");
-import {dest, src, watch} from "vinyl-fs";
+import * as Orchestrator from "orchestrator";
+import {dest, src} from "vinyl-fs";
+import {EventEmitter} from "events";
+
+// ** hotfix for watch() not being in typings (copied over from @types/vinyl-fs) **
+
+/**
+ * This is just a glob-watcher
+ *
+ * @param globs Takes a glob string or an array of glob strings as the first argument
+ * Globs are executed in order, so negations should follow positive globs
+ * fs.src(['!b*.js', '*.js']) would not exclude any files, but this would: fs.src(['*.js', '!b*.js'])
+ */
+declare function watch(globs: string|string[], cb?: (outEvt: { type: any; path: any; old: any; }) => void): EventEmitter;
+
+/**
+ * This is just a glob-watcher
+ *
+ * @param globs Takes a glob string or an array of glob strings as the first argument
+ * Globs are executed in order, so negations should follow positive globs
+ * fs.src(['!b*.js', '*.js']) would not exclude any files, but this would: fs.src(['*.js', '!b*.js'])
+ */
+declare function watch(globs: string|string[], opt?: { interval?: number; debounceDelay?: number; cwd?: string; maxListeners?: Function; }, cb?: (outEvt: { type: any; path: any; old: any; }) => void): EventEmitter;
+
+// ** hotfix end **
 
 declare interface RunMethod {
   /**

--- a/3.9.1/index.d.ts
+++ b/3.9.1/index.d.ts
@@ -2,6 +2,10 @@
 // Project: http://gulpjs.com
 // Definitions by: Marcel Mundl <Marcel@Mundlhome.de>
 
+/// <reference types="orchestrator"/>
+/// <reference types="vinyl-fs"/>
+/// <reference types="node"/>
+
 import * as Orchestrator from "orchestrator";
 import {dest, src} from "vinyl-fs";
 import {EventEmitter} from "events";

--- a/3.9.1/index.d.ts
+++ b/3.9.1/index.d.ts
@@ -5,7 +5,21 @@
 import Orchestrator = require("orchestrator");
 import {dest, src, watch} from "vinyl-fs";
 
-declare class Gulp extends Orchestrator {
+declare interface RunMethod {
+  /**
+   * Run the "default" task
+   * @deprecated will be removed in gulp 4.0. Use task dependencies instead.
+   */
+  (): void;
+  /**
+   * Run a previously defined task
+   * @param taskName The name of the task to run (optional)
+   * @deprecated will be removed in gulp 4.0. Use task dependencies instead.
+   */
+  (taskName: string): void;
+}
+
+declare interface GulpPrototype {
   dest: typeof dest;
   src: typeof src;
   /**
@@ -24,22 +38,15 @@ declare class Gulp extends Orchestrator {
   /**
    * The class is a member of itself so that packages can create seperate instances of gulp
    */
-  Gulp: typeof Gulp;
+  Gulp: GulpStatic;
 }
 
-declare interface RunMethod {
-  /**
-   * Run the "default" task
-   * @deprecated will be removed in gulp 4.0. Use task dependencies instead.
-   */
-  (): void;
-  /**
-   * Run a previously defined task
-   * @param taskName The name of the task to run (optional)
-   * @deprecated will be removed in gulp 4.0. Use task dependencies instead.
-   */
-  (taskName: string): void;
+declare type Gulp = GulpPrototype;
+
+declare interface GulpStatic {
+  new (): Gulp;
+  prototype: GulpPrototype;
 }
 
-declare let inst: Gulp;
+declare let inst: GulpPrototype;
 export = inst;

--- a/3.9.1/index.d.ts
+++ b/3.9.1/index.d.ts
@@ -2,10 +2,6 @@
 // Project: http://gulpjs.com
 // Definitions by: Marcel Mundl <Marcel@Mundlhome.de>
 
-/// <reference types="orchestrator"/>
-/// <reference types="vinyl-fs"/>
-/// <reference types="node"/>
-
 import * as Orchestrator from "orchestrator";
 import {dest, src} from "vinyl-fs";
 import {EventEmitter} from "events";

--- a/3.9.1/typings.json
+++ b/3.9.1/typings.json
@@ -7,6 +7,7 @@
     "node": "registry:env/node#6.0.0+20160813135048"
   },
   "dependencies": {
-    "orchestrator": "registry:npm/orchestrator#0.3.7+20160723033700"
+    "orchestrator": "registry:npm/orchestrator#0.3.7+20160723033700",
+    "vinyl-fs": "registry:npm/vinyl-fs#2.4.3+20160817102725"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
   },
   "homepage": "https://github.com/typed-typings/npm-gulp",
   "devDependencies": {
-    "@types/orchestrator": "0.0.30",
-    "@types/vinyl-fs": "0.0.28",
     "typescript": "^1.8.10",
     "typings": "^1.0.4"
   }

--- a/package.json
+++ b/package.json
@@ -8,25 +8,20 @@
     "prepare-3.8.0": "echo Installing typings in 3.8.0... && cd 3.8.0 && typings install",
     "prepare-3.9.1": "echo Installing typings in 3.9.1... && cd 3.9.1 && typings install",
     "prepare-4.0.0-alpha.2": "echo Installing typings in 4.0.0-alpha.2... && cd 4.0.0-alpha.2 && typings install",
-  
     "build-ts": "echo Starting building... &&  npm run build-ts-3.8.0 & npm run build-ts-3.9.1 & npm run build-ts-4.0.0-alpha.2  && echo Build typescript completed.",
     "build-ts-3.8.0": "echo Building typescript in 3.8.0... && tsc -p 3.8.0",
     "build-ts-3.9.1": "echo Building typescript in 3.9.1... && tsc -p 3.9.1",
     "build-ts-4.0.0-alpha.2": "echo Building typescript in 4.0.0-alpha.2... && tsc -p 4.0.0-alpha.2",
-    
     "bundle": "echo Starting bundling... && npm run bundle-3.8.0 & npm run bundle-3.9.1 & npm run bundle-4.0.0-alpha.2",
     "bundle-3.8.0": "echo Bundling typings in 3.8.0... && cd 3.8.0 && typings bundle -o out/index.d.ts",
     "bundle-3.9.1": "echo Bundling typings in 3.9.1... && cd 3.9.1 && typings bundle -o out/index.d.ts",
     "bundle-4.0.0-alpha.2": "echo Bundling typings in 4.0.0-alpha.2... && cd 4.0.0-alpha.2 && typings bundle -o out/index.d.ts",
-    
     "test": "echo Starting tests... && npm run test-3.8.0 & npm run test-3.9.1 & npm run test-4.0.0-alpha.2",
     "test-3.8.0": "echo Runing test in 3.8.0... && tsc -p 3.8.0/test && echo Test in 3.8.0 successfully completed.",
     "test-3.9.1": "echo Runing test in 3.9.1... && tsc -p 3.9.1/test && echo Test in 3.9.1 successfully completed.",
     "test-4.0.0-alpha.2": "echo Runing test in 4.0.0-alpha.2... && tsc -p 4.0.0-alpha.2/test && echo Test in 4.0.0-alpha.2 successfully completed.",
-    
-    "build": "npm run build-ts && npm run bundle",  
+    "build": "npm run build-ts && npm run bundle",
     "build+test": "npm run prepare && npm run build && npm run test",
-    
     "cleanup-typings": "echo Removing typings folders... && for /d /r . %d in (typings) do @if exist %d rd /s/q %d",
     "cleanup-out": "echo Removing out folders... && for /d /r . %d in (out) do @if exist %d rd /s/q %d",
     "cleanup": "npm run cleanup-typings && npm run cleanup-out"
@@ -38,6 +33,8 @@
   },
   "homepage": "https://github.com/typed-typings/npm-gulp",
   "devDependencies": {
+    "@types/orchestrator": "0.0.30",
+    "@types/vinyl-fs": "0.0.28",
     "typescript": "^1.8.10",
     "typings": "^1.0.4"
   }


### PR DESCRIPTION
Since most of gulp is just passing through to orchestrator and vinyl it seems the obvious thing for me to utilize the typings of those projects to make the gulp typings smaller and easier to understand. Beyond that I added Gulp.prototype.Gulp because the previous definitions file missed it.